### PR TITLE
Added simple_wait.yaml story and updated syntax to allow green tests

### DIFF
--- a/src/engine/syntax.py
+++ b/src/engine/syntax.py
@@ -177,6 +177,11 @@ class Return(Map):
 
 
 @dataclass
+class Wait(Map):
+    spec: Tags = (Tag("wait", Null),)
+
+
+@dataclass
 class Variable(Expression):
     pattern: str = "^[a-zA-Z_][a-zA-Z0-9_]*$"
 
@@ -187,9 +192,9 @@ class Text(Expression):
 
 
 simple_syntax = initial_syntax.extend(
-    If, A, Variable, Doc, Block, Goto, GoSub, Choice, Print, Error, Text, Null, Return
+    If, A, Variable, Doc, Block, Goto, GoSub, Choice, Print, Error, Text, Null, Return, Wait
 )
 syntax_v1 = simple_syntax
 
 
-node_class_dict = {"A": A, "print": Print}
+node_class_dict = {"A": A, "print": Print, "wait": Wait}

--- a/src/engine/syntax.py
+++ b/src/engine/syntax.py
@@ -192,7 +192,20 @@ class Text(Expression):
 
 
 simple_syntax = initial_syntax.extend(
-    If, A, Variable, Doc, Block, Goto, GoSub, Choice, Print, Error, Text, Null, Return, Wait
+    If,
+    A,
+    Variable,
+    Doc,
+    Block,
+    Goto,
+    GoSub,
+    Choice,
+    Print,
+    Error,
+    Text,
+    Null,
+    Return,
+    Wait,
 )
 syntax_v1 = simple_syntax
 

--- a/tests/stories/simple_wait.yaml
+++ b/tests/stories/simple_wait.yaml
@@ -1,0 +1,31 @@
+---
+blocks:
+  - name: start
+    start: true
+    content:
+      - print: |
+          This is the start of the program.
+      - choice: continue
+        text: Continue
+        effects:
+          - print: |
+              You chose to continue.
+      - choice: goto
+        text: Go somewhere else
+        effects:
+          - print: |
+              You chose to go to the other block.
+          - goto: /other_block
+      - wait:
+      - print: |
+          You have continued. This should not appear until after you've made a choice.
+      - print: |
+          You should now only be presented with the 'Go somewhere else' choice.
+      - wait:
+      - error:
+  - name: other_block
+    content:
+      - print: |
+          You are in the other block.
+      - print: |
+          This is the end of the story.


### PR DESCRIPTION
Tests should be green; just added the simple_wait.yaml that hopefully demonstrates some of the complexity of the wait function. There are two control branches based on the choice made.